### PR TITLE
Update AbstractNormForm.php

### DIFF
--- a/src/Core/AbstractNormForm.php
+++ b/src/Core/AbstractNormForm.php
@@ -82,13 +82,9 @@ abstract class AbstractNormForm
         if ($this->isFormSubmission()) {
             if ($this->isValid()) {
                 $this->business();
-                $this->show();
-            } else {
-                $this->show();
             }
-        } else {
-            $this->show();
         }
+        $this->show();
     }
 
     /**


### PR DESCRIPTION
The method normForm() can be easier, because show() requires no parameter any longer.
Therefore calling show() once is enough